### PR TITLE
Update sonos to 5.1.1

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,8 +4,8 @@
 #
 #   include sonos
 class sonos {
-  package { 'SonosDesktopController50':
+  package { 'SonosDesktopController511':
     provider => 'appdmg_eula',
-    source   => 'http://update.sonos.com/software/mac/mdcr/SonosDesktopController50.dmg'
+    source   => 'http://update.sonos.com/software/mac/mdcr/SonosDesktopController511.dmg'
   }
 }

--- a/spec/classes/sonos_spec.rb
+++ b/spec/classes/sonos_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 describe 'sonos' do
   it do
-    should contain_package('SonosDesktopController50').with({
+    should contain_package('SonosDesktopController511').with({
       :provider => 'appdmg_eula',
-      :source   => 'http://update.sonos.com/software/mac/mdcr/SonosDesktopController50.dmg',
+      :source   => 'http://update.sonos.com/software/mac/mdcr/SonosDesktopController511.dmg',
     })
   end
 end


### PR DESCRIPTION
This is the latest version. Also, the last release tag on puppet-sonos is for version 4.2, which doesn't complete install. It requires an upgrade. Even after installing 5.1.1, the Sonos app indicates that there is an upgrade....to 5.1.1. It works at least.
